### PR TITLE
Fix: 납부 확인 버튼 무한로딩 버그 수정

### DIFF
--- a/loading/loading.php
+++ b/loading/loading.php
@@ -46,7 +46,7 @@
         </head>
         <body>
             <div class="spinner-wrapper" id="spinner-wrapper">
-                <div class="spinner"></div>
+                <div class="spinner" id="spinner"></div>
             </div>
         </body>
         </html>

--- a/view/match.php
+++ b/view/match.php
@@ -251,7 +251,7 @@
                 }
             });
         } else {
-            const loading = document.getElementById("spinner-wrapper");
+            const loading = document.getElementById("spinner");
             loading.parentNode.removeChild(loading);
         }
     }


### PR DESCRIPTION
Fix
 - 납부 확인 버튼 무한로딩 버그 수정
 
버그 이유
 const loading = document.getElementById("spinner-wrapper");
 loading.parentNode.removeChild(loading);
 parentNode는 부모 컨테이너를 선택할 때 사용.
 그런데 spinner-wrapper는 최상위 div 컨테이너임
 부모 컨테이너가 없는 상태에서 부모 컨테이너를 선택하려고 해서 에러가 남
 
수정 방법
 spinner-wrapper를 불러오는게 아닌 spinner를 불러오는 것으로 수정
 ->  spinner-wrapper의 자식 컨테이너에 spinner id 추가